### PR TITLE
Fix null pointer on empty application class

### DIFF
--- a/src/decorators/application.decorator.ts
+++ b/src/decorators/application.decorator.ts
@@ -8,6 +8,7 @@ import { ApplicationConfig, Middleware } from '../index';
 import {
     ComponentStore,
     componentStore,
+    emptyComponent,
     EndpointFactory,
     RequestListenerFactory,
     Router
@@ -47,6 +48,9 @@ export function Application(config: ApplicationConfig) {
             store.componentRoute = '';
             store.componentMiddleware = [];
             componentStore.set(constructor.name, store);
+        } else {
+            const store: ComponentStore = emptyComponent();
+            componentStore.set(constructor.name, store);
         }
 
         const router: Router = new Router();
@@ -58,7 +62,7 @@ export function Application(config: ApplicationConfig) {
 
         if (config.server.https) {
             https.createServer(config.server.https, RequestListenerFactory(config, router))
-                .listen(config.server.port || 443, () =>{
+                .listen(config.server.port || 443, () => {
                     console.log(colors.green(`[SUCCESS]\tApi is up and listening on port ${config.server.port || 443}`));
                     console.log('[INFO]\t\tUsing schema https');
                 });

--- a/src/store/component.store.ts
+++ b/src/store/component.store.ts
@@ -22,3 +22,16 @@ export interface ComponentStore {
  * @hidden
  */
 export const componentStore: Map<string, ComponentStore> = new Map();
+
+export function emptyComponent(): ComponentStore {
+    return <ComponentStore>{
+        componentMiddleware: [] as Middleware,
+        componentRoute: null,
+        endpoints: [] as Array<EndpointHandler>,
+        get: [] as Array<EndpointHandler>,
+        post: [] as Array<EndpointHandler>,
+        patch: [] as Array<EndpointHandler>,
+        put: [] as Array<EndpointHandler>,
+        delete: [] as Array<EndpointHandler>
+    };
+}

--- a/src/util/factory/endpoint.factory.ts
+++ b/src/util/factory/endpoint.factory.ts
@@ -6,6 +6,7 @@ import {
     checkHandlerFunctionIndexSignature,
     ComponentStore,
     componentStore,
+    emptyComponent,
     EndpointHandler,
     Injector,
     ModuleStore,
@@ -36,16 +37,7 @@ export class EndpointFactory {
                 });
                 componentStore.set(target.constructor.name, store);
             } else {
-                const stored: ComponentStore = {
-                    componentMiddleware: [] as Middleware,
-                    componentRoute: null,
-                    endpoints: [] as Array<EndpointHandler>,
-                    get: [] as Array<EndpointHandler>,
-                    post: [] as Array<EndpointHandler>,
-                    patch: [] as Array<EndpointHandler>,
-                    put: [] as Array<EndpointHandler>,
-                    delete: [] as Array<EndpointHandler>
-                };
+                const stored: ComponentStore = emptyComponent();
                 stored[selectedEndpointArray] = new Array<EndpointHandler>({
                     functionContextInstance: target,
                     fn: target[key] as Function,


### PR DESCRIPTION
When an application decorated class dont contain any endpoints it will throw an error
`Component has no mapped class.` This PR will fix this. 
#39 caused some issues because the empty object was overridden. now a function is called, that returns a new empty ComponentStore object instead